### PR TITLE
Resolves #20: Include python 3.6 in tox and travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,5 +11,3 @@ install: pip install -U tox-travis
 
 # Command to run tests, e.g. python setup.py test
 script: tox
-
-

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,11 @@
 [tox]
-envlist = py37, py38, flake8
+envlist = py36, py37, py38, flake8
 
 [travis]
 python =
     3.8: py38
     3.7: py37
+    3.6: py36
 
 [testenv:flake8]
 basepython = python


### PR DESCRIPTION
Vuelvo a incluir python 3.6. Resulta que el error de SSL era por culpa de mi instalación vía brew, pero el proyecto funciona perfectamente contra esa versión de pyhton.