### PR TITLE
Compare with less precision to avoid eventual fails in route between two points

### DIFF
--- a/tests/test_route_between_two_points.py
+++ b/tests/test_route_between_two_points.py
@@ -19,30 +19,31 @@ class TestRouteBetweenTwoPoints(unittest.TestCase):
 
     def test_001_route_between_two_points(self):
         """Test the route between two points using the distance,
-            when is not using a vehicle"""
+        when is not using a vehicle"""
 
-        lat_init, lon_init, lat_dest, lon_dest = 40.4166896, -3.7038101, 40.4113844, -3.7083022
-
-        self.assertEqual(
-                         route_between_two_points(lat_init=lat_init, lon_init=lon_init,
-                                                  lat_dest=lat_dest, lon_dest=lon_dest,
-                                                  vehicle=False)['distance'], 815.7369613261391)
+        lat_init, lon_init, lat_dest, lon_dest = 40.4167, -3.7038, 40.4114, -3.7083
+        result = route_between_two_points(
+            lat_init=lat_init, lon_init=lon_init, lat_dest=lat_dest, lon_dest=lon_dest, vehicle=False
+        )
+        result_distance = result['distance']
+        self.assertGreater(result_distance, 750)
+        self.assertLess(result_distance, 900)
 
     def test_002_route_between_two_points(self):
         """Test the route between two points using the distance,
-            when using a vehicle"""
+        when using a vehicle"""
 
-        lat_init, lon_init, lat_dest, lon_dest = 40.4166896, -3.7038101, 40.4113844, -3.7083022
-
-        self.assertEqual(
-                         route_between_two_points(lat_init=lat_init, lon_init=lon_init,
-                                                  lat_dest=lat_dest, lon_dest=lon_dest,
-                                                  vehicle=True)['distance'], 815.736961326139)
+        lat_init, lon_init, lat_dest, lon_dest = 40.4167, -3.7038, 40.4114, -3.7083
+        result = route_between_two_points(
+            lat_init=lat_init, lon_init=lon_init, lat_dest=lat_dest, lon_dest=lon_dest, vehicle=False
+        )
+        result_distance = result['distance']
+        self.assertGreater(result_distance, 750)
+        self.assertLess(result_distance, 900)
 
     def test_003_route_between_two_points(self):
         """Test correct args type"""
-        self.assertEqual(route_between_two_points('lat1', 'lon1', 'lat2', 'lon2',
-                                                  error='ignore'), {})
+        self.assertEqual(route_between_two_points('lat1', 'lon1', 'lat2', 'lon2', error='ignore'), {})
 
     def test_004_route_between_two_points(self):
         """Test correct args raising exception"""
@@ -51,13 +52,12 @@ class TestRouteBetweenTwoPoints(unittest.TestCase):
 
     def test_005_route_between_two_points(self):
         # Test coords not found
-        self.assertEqual(route_between_two_points(40.4166896, -3.7038101, 0, 0,
-                                                  error='ignore'), {})
+        self.assertEqual(route_between_two_points(40.4167, -3.7038, 0, 0, error='ignore'), {})
 
     def test_006_route_between_two_points(self):
         # Test coords not found raising exception
         with self.assertRaises(SystemExit):
-            route_between_two_points(40.4166896, -3.7038101, 0, 0)
+            route_between_two_points(40.4167, -3.7038, 0, 0)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Compara con rangos y con menos decimales en los tests, para evitar errores puntuales por precisión o cambios mínimos en el callejero